### PR TITLE
Prepare the link directory

### DIFF
--- a/foxy/remote/Dockerfile
+++ b/foxy/remote/Dockerfile
@@ -60,7 +60,8 @@ RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc && \
     echo "source /usr/share/vcstool-completion/vcs.bash" >> ~/.bashrc
 
 # https://answers.ros.org/question/372890/rqt-button-not-show-icon/
-RUN ln -s /usr/share/icons/Tango ~/.icons/hicolor
+RUN mkdir ~/.icons && \
+    ln -s /usr/share/icons/Tango ~/.icons/hicolor
 
 RUN echo "alias vi=nvim" >> ~/.bash_aliases
 


### PR DESCRIPTION
Fix the following error:
```
ln: failed to create symbolic link '/root/.icons/hicolor': No such file
or directory
The command '/bin/bash -c ln -s /usr/share/icons/Tango ~/.icons/hicolor'
returned a non-zero code: 1
ERROR: Service 'remote' failed to build : Build failed
```